### PR TITLE
simplified HOTP operations using struct

### DIFF
--- a/oath/_hotp.py
+++ b/oath/_hotp.py
@@ -30,7 +30,6 @@ def dec(h,p):
     digits = str(truncated_value(h))
     return digits[-p:].zfill(p)
 
-
 def int2beint64(i):
     return struct.pack('>Q', int(i))
 


### PR DESCRIPTION
Three functions of the `hotp` module performed such format conversions "manually" that are provided by the `struct` module. The unit tests ran fine, the code is shorter and IMHO more readable -- and could be even faster (no unnecessary modulos and intermediate formats), although I haven't measured that.
