### PR TITLE
Google authenticator improvements

### DIFF
--- a/oath/google_authenticator.py
+++ b/oath/google_authenticator.py
@@ -43,6 +43,7 @@ def parse_otpauth(otpauth_uri):
         raise ValueError('Invalid otpauth URI', otpauth_uri)
 
     params = dict(((k, v[0]) for k, v in urlparse.parse_qs(parsed_uri.query).items()))
+    params[LABEL] = parsed_uri.path[1:]
     params[TYPE] = parsed_uri.hostname
 
     if SECRET not in params:
@@ -104,6 +105,10 @@ class GoogleAuthenticator(object):
         self.parsed_otpauth_uri = parse_otpauth(otpauth_uri)
         self.generator_state = state or {}
         self.acceptor_state = state or {}
+
+    @property
+    def label(self):
+        return self.parsed_otpauth_uri[LABEL]
 
     def generate(self, t=None):
         format = 'dec%s' % self.parsed_otpauth_uri[DIGITS]


### PR DESCRIPTION
I have a bunch of otpath:// URLs from a variety of services, and many of them are a bit sloppy with the secret (skipping padding, using lowercase values, etc), which caused the GoogleAuthenticator constructor to fail. I noticed the from_b32key function did some sanitizing of the secret, but as I have full URLs I'd prefer not to have to extract the secret just to use that function. Instead I've made it so both from_b32key and the GoogleAuthenticator constructor are able to deal with these "sloppy" secrets, as well as some other minor cleanups of the code.
