### PR TITLE
Fix type error in token comparison with python 2.7

### DIFF
--- a/oath/_hotp.py
+++ b/oath/_hotp.py
@@ -1,6 +1,5 @@
 import hashlib
 import hmac
-import binascii
 import struct
 
 from . import _utils
@@ -37,7 +36,7 @@ def int2beint64(i):
 
 def __hotp(key, counter, hash=hashlib.sha1):
     bin_counter = int2beint64(counter)
-    bin_key = binascii.unhexlify(key.encode('ascii'))
+    bin_key = _utils.fromhex(key)
 
     return hmac.new(bin_key, bin_counter, hash).digest()
 
@@ -83,7 +82,7 @@ def hotp(key,counter,format='dec6',hash=hashlib.sha1):
     elif format == 'hex':
         return '%x' % truncated_value(bin_hotp)
     elif format == 'hex-notrunc':
-        return binascii.hexlify(bin_hotp).decode('ascii')
+        return _utils.tohex(bin_hotp)
     elif format == 'bin':
         return bin_hotp
     elif format == 'dec':

--- a/oath/_totp.py
+++ b/oath/_totp.py
@@ -126,6 +126,6 @@ def accept_totp(key, response, format='dec6', period=30, t=None,
         t = int(time.time())
     for i in range(max(-divmod(t, period)[0],-backward_drift),forward_drift+1):
         d = (drift+i) * period
-        if _utils.compare_digest(totp(key, format=format, period=period, hash=hash, t=t+d), str(response)):
+        if _utils.compare_digest(totp(key, format=format, period=period, hash=hash, t=t+d), response):
             return True, drift+i
     return False, 0

--- a/oath/_utils.py
+++ b/oath/_utils.py
@@ -6,12 +6,17 @@ except ImportError:
 
 if hasattr(bytes, 'fromhex'):
     # Python 3.x
+    import binascii
     def fromhex(s):
         return bytes.fromhex(s)
+    def tohex(bin):
+        return binascii.hexlify(bin).decode('ascii')
 else:
     # Python 2.x
     def fromhex(s):
         return s.decode('hex')
+    def tohex(bin):
+        return bin.encode('hex')
 
 def tobytes(b_or_s):
     try:

--- a/oath/google_authenticator.py
+++ b/oath/google_authenticator.py
@@ -16,10 +16,10 @@ except ImportError:
     from urllib.parse import urlparse, parse_qs, urlencode
 import base64
 import hashlib
-import binascii
 
 from oath import _hotp as hotp
 from oath import _totp as totp
+from . import _utils
 
 __all__ = ('GoogleAuthenticator', 'from_b32key')
 
@@ -55,7 +55,7 @@ def parse_otpauth(otpauth_uri):
     if SECRET not in params:
         raise ValueError('Missing secret field in otpauth URI', otpauth_uri)
     try:
-        params[SECRET] = binascii.hexlify(lenient_b32decode(params[SECRET])).decode('ascii')
+        params[SECRET] = _utils.tohex(lenient_b32decode(params[SECRET]))
     except TypeError:
         raise ValueError('Invalid base32 encoding of the secret field in '
                 'otpauth URI', otpauth_uri)


### PR DESCRIPTION
I'm using this simple code to test python-oath:

import oath
from Crypto import Random
import binascii
day = 24 * 60 * 60
key = binascii.hexlify(Random.get_random_bytes(16)).decode('ascii')
print("key = {0}".format(key))
token = oath.totp(key, format='hex-notrunc', period = day)
print("token = {0} {1}".format(token, type(token)))
(ok, drift) = oath.accept_totp(key, response, format='hex-notrunc', period = day, backward_drift = 2)
print("ok = {0}, drift = {1}".format(ok, drift))

but this results in a TypeError under python 2.7:

python test.py 
key = c2b0bd28f9d9da8c7375fa6321448397
token = b767fe972a7e4626b2c7ad578c4b1fa4ccd29f1f \<type 'unicode'\>
Traceback (most recent call last):
  File "test.py", line 15, in <module>
    (ok, drift) = oath.accept_totp(key, response, format='hex-notrunc', period = day, backward_drift = 2)
  File "/usr/lib/python2.7/dist-packages/oath/_totp.py", line 129, in accept_totp
    if _utils.compare_digest(totp(key, format=format, period=period, hash=hash, t=t+d), str(response)):
  File "/usr/lib/python2.7/dist-packages/oath/_utils.py", line 27, in compare_digest
    raise TypeError
TypeError
