### PR TITLE
export fromhex/tohex in oath module

### DIFF
--- a/oath/__init__.py
+++ b/oath/__init__.py
@@ -2,5 +2,6 @@ from oath._totp import *
 from oath._hotp import *
 from oath._ocra import *
 from oath.google_authenticator import *
+from oath._utils import fromhex, tohex
 
 __version__ = VERSION = '1.3.0'


### PR DESCRIPTION
When using python-oath I have the same byte/str/unicode type problem in my own modules that python-oath had, e.g. when I generate the key for the tokens. It would be nice if python-oath would export the fromhex and tohex functions so users don't have to build their own.
