### PR TITLE
Test only active Python versions with TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
-  - "3.4"
+  - "3.6"
+  - "3.7"
+  - "3.8"
+  - "3.9"
+  - "3.10"
 script: python setup.py test


### PR DESCRIPTION
Active Python releases as defined here: https://www.python.org/downloads/

TravisCI seems to have dropped support for 3.3 and 2.6.