### PR TITLE
docs: Fix a few typos

### DIFF
--- a/oath/_ocra.py
+++ b/oath/_ocra.py
@@ -125,7 +125,7 @@ class DataInput(object):
        OCRA data input description
 
        By calling this instance of this class and giving the needed parameter
-       corrresponding to the data input description, it compute a binary string
+       corresponding to the data input description, it compute a binary string
        to give to the HMAC algorithme implemented by a CryptoFunction object
     '''
 

--- a/oath/_totp.py
+++ b/oath/_totp.py
@@ -76,7 +76,7 @@ def accept_totp(
 ):
     '''
        Validate a TOTP value inside a window of 
-       [drift-bacward_drift:drift+forward_drift] of time steps.
+       [drift-backward_drift:drift+forward_drift] of time steps.
        Where drift is the drift obtained during the last call to accept_totp.
 
        :param response:

--- a/oath/_utils.py
+++ b/oath/_utils.py
@@ -1,7 +1,7 @@
 try:
     from functools import reduce
 except ImportError:
-    # not necesary in Python 2.x
+    # not necessary in Python 2.x
     pass
 
 if hasattr(bytes, 'fromhex'):

--- a/oath/google_authenticator.py
+++ b/oath/google_authenticator.py
@@ -5,7 +5,7 @@ Google Authenticator API
 ------------------------
 
 Google Authenticator is based on HOTP and TOTP. It provides a simple way of
-provisionning an OTP generator through a new URL scheme.
+provisioning an OTP generator through a new URL scheme.
 
 This module provides parsing and high-level API over the classic HOTP and TOTP
 APIs provided by the oath.hotp and oath.totp modules.

--- a/tests/test_totp.py
+++ b/tests/test_totp.py
@@ -12,7 +12,7 @@ def parse_tv(tv):
 
 
 class Totp(unittest.TestCase):
-    key_seed = '1234567890'.encode('ascii')  # no effect in Python 2.x but makes a bytes intance in Python 3.x
+    key_seed = '1234567890'.encode('ascii')  # no effect in Python 2.x but makes a bytes instance in Python 3.x
     key_sha1 = binascii.hexlify(key_seed * 2).decode('ascii')
     key_sha256 = binascii.hexlify(key_seed * 3 + '12'.encode('ascii')).decode('ascii')
     key_sha512 = binascii.hexlify(key_seed * 6 + '1234'.encode('ascii')).decode('ascii')


### PR DESCRIPTION
There are small typos in:
- oath/_ocra.py
- oath/_totp.py
- oath/_utils.py
- oath/google_authenticator.py
- tests/test_totp.py

Fixes:
- Should read `provisioning` rather than `provisionning`.
- Should read `necessary` rather than `necesary`.
- Should read `instance` rather than `intance`.
- Should read `corresponding` rather than `corrresponding`.
- Should read `backward` rather than `bacward`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md