### PR TITLE
Remove incorrect license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         'Intended Audience :: Developers',
-        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",


### PR DESCRIPTION
OSI approved classifier has been deprecated from Python packaging guidelines.